### PR TITLE
Fixed tr1 namespace compilation error with Android LLVM C++11.

### DIFF
--- a/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/estimate_propagator.h
+++ b/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/estimate_propagator.h
@@ -34,7 +34,7 @@
 #include <set>
 #include <limits>
 
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -135,7 +135,11 @@ namespace g2o {
           size_t operator ()(const OptimizableGraph::Vertex* v) const { return v->id();}
       };
 
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
+      typedef std::unordered_map<OptimizableGraph::Vertex*, AdjacencyMapEntry, VertexIDHashFunction> AdjacencyMap;
+#else
       typedef std::tr1::unordered_map<OptimizableGraph::Vertex*, AdjacencyMapEntry, VertexIDHashFunction> AdjacencyMap;
+#endif
 
     public:
       EstimatePropagator(OptimizableGraph* g);

--- a/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/hyper_graph.h
+++ b/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/hyper_graph.h
@@ -35,7 +35,7 @@
 #include <limits>
 #include <cstddef>
 
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -90,7 +90,12 @@ namespace g2o {
       typedef std::set<Edge*>                           EdgeSet;
       typedef std::set<Vertex*>                         VertexSet;
 
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
+      typedef std::unordered_map<int, Vertex*>          VertexIDMap;
+#else
       typedef std::tr1::unordered_map<int, Vertex*>     VertexIDMap;
+#endif
+
       typedef std::vector<Vertex*>                      VertexContainer;
 
       //! abstract Vertex, your types must derive from that one

--- a/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/marginal_covariance_cholesky.h
+++ b/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/marginal_covariance_cholesky.h
@@ -33,7 +33,7 @@
 #include <cassert>
 #include <vector>
 
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -50,8 +50,12 @@ namespace g2o {
       /**
        * hash struct for storing the matrix elements needed to compute the covariance
        */
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
+      typedef std::unordered_map<int, double>          LookupMap;
+#else
       typedef std::tr1::unordered_map<int, double>     LookupMap;
-    
+#endif
+
     public:
       MarginalCovarianceCholesky();
       ~MarginalCovarianceCholesky();

--- a/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/robust_kernel.h
+++ b/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/robust_kernel.h
@@ -27,7 +27,7 @@
 #ifndef G2O_ROBUST_KERNEL_H
 #define G2O_ROBUST_KERNEL_H
 
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
 #include <memory>
 #else
 #include <tr1/memory>
@@ -74,7 +74,12 @@ namespace g2o {
     protected:
       double _delta;
   };
+
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
+  typedef std::shared_ptr<RobustKernel> RobustKernelPtr;
+#else
   typedef std::tr1::shared_ptr<RobustKernel> RobustKernelPtr;
+#endif
 
 } // end namespace g2o
 

--- a/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/sparse_block_matrix_ccs.h
+++ b/app/src/main/cpp/ORB/Thirdparty/g2o/g2o/core/sparse_block_matrix_ccs.h
@@ -34,7 +34,7 @@
 #include "../../config.h"
 #include "matrix_operations.h"
 
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -223,7 +223,11 @@ namespace g2o {
       //! rows of the matrix
       int rows() const {return _rowBlockIndices.size() ? _rowBlockIndices.back() : 0;}
 
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1600) // C++11
+      typedef std::unordered_map<int, MatrixType*> SparseColumn;
+#else
       typedef std::tr1::unordered_map<int, MatrixType*> SparseColumn;
+#endif
 
       SparseBlockMatrixHashMap(const std::vector<int>& rowIndices, const std::vector<int>& colIndices) :
         _rowBlockIndices(rowIndices), _colBlockIndices(colIndices)


### PR DESCRIPTION
- Fixed tr1 namespace compilation error with Android LLVM C++11 compiler (used Android NDK 21.1.6352462 package)
- Added conditional preprocessor directives

